### PR TITLE
Modify normalizeDate function to remove parenthesis

### DIFF
--- a/setup/setup.js
+++ b/setup/setup.js
@@ -29,16 +29,14 @@ function arrayFieldToString (fieldValue) {
 
 // Get year from Date field and add it to new field to make sorting by date easier
 function normalizeDate (document) {
-  const date = document.Date
-  const match = (/(\d{4})/).exec(date)
-  const parenthesis = (/[()]/g).exec(date)
-
-  if (match) {
-    document.DateToSortBy = match[0]
-  } else if (parenthesis) {
-    document.DateToSortBy = date.replace(/[()]/g, '')
+  let date = document.Date
+  if (date == null) {
+    document.DateToSortBy = 0
   } else {
-    document.DateToSortBy = date
+    date = date.replace(/\((.*)\)/, '$1') // removes parenthesis
+    date = date.replace(/.*([0-9]{4}).*/, '$1') // fetch the 4 first digits if exist
+    date = date.replace(/^[^0-9]{4}.*/, '0') // Change all fields with no valid year ( 4 digits in a row ) to 0
+    document.DateToSortBy = parseInt(date) // parse all values to int
   }
   return document
 }

--- a/setup/setup.js
+++ b/setup/setup.js
@@ -31,8 +31,12 @@ function arrayFieldToString (fieldValue) {
 function normalizeDate (document) {
   const date = document.Date
   const match = (/(\d{4})/).exec(date)
+  const parenthesis = (/[()]/g).exec(date)
+
   if (match) {
     document.DateToSortBy = match[0]
+  } else if (parenthesis) {
+    document.DateToSortBy = date.replace(/[()]/g, '')
   } else {
     document.DateToSortBy = date
   }

--- a/setup/setup.unit.test.js
+++ b/setup/setup.unit.test.js
@@ -67,15 +67,15 @@ describe('normalizeDate', () => {
   })
   test('DateToSortBy field should be equal to the year of the date field if a year exists', () => {
     result = setupFunctions.normalizeDate(document)
-    expect(result.DateToSortBy).toEqual('1881')
+    expect(result.DateToSortBy).toEqual(1881)
     const document2 = { Artist: ['Auguste Renoir'], Date: '25/02/1841' }
     const result2 = setupFunctions.normalizeDate(document2)
-    expect(result2.DateToSortBy).toEqual('1841')
+    expect(result2.DateToSortBy).toEqual(1841)
   })
-  test('DateToSortBy field should be equal to the date field if no year exists', () => {
+  test('DateToSortBy field should be equal to 0 if no year exists', () => {
     const documentWithNoYear = { Artist: ['René Magritte'], Date: 'Unknown' }
     result = setupFunctions.normalizeDate(documentWithNoYear)
-    expect(result.DateToSortBy).toEqual(documentWithNoYear.Date)
+    expect(result.DateToSortBy).toEqual(0)
   })
 })
 


### PR DESCRIPTION
Currently, the date field can have both `(n.d.)` and `n.d` values, which is disturbing when using the sort feature. When sorting in ascending order: the parenthesis comes first in the search results, then the actual dates, then the letters. So we have `(n.d.)` at the beginning of the results and` n.d` at the end. 